### PR TITLE
Add AI card suggestion and turn system

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,24 +9,40 @@ A dark-themed, arcane-tech card and map strategy game that combines tactical gam
 - Dark theme with arcane aesthetics
 - Modern UI components with responsive design
 - Rich lore and immersive world-building
+- Optional AI card suggestion in the forge screen
 
 ## Getting Started
 
 ### Prerequisites
-- Python 3.8 or higher
-- PySide6/PyQt6 for desktop application
+- Node.js 18+
+- pnpm package manager (`npm install -g pnpm`)
 - Modern web browser for web components
 
 ### Installation
 1. Clone the repository
-2. Install dependencies
-3. Follow the setup instructions in the documentation
+2. Install dependencies using `pnpm install`
+3. Start the web client with `pnpm dev:web` or the desktop app with `pnpm dev:desktop`
+4. Run all tests with `pnpm test`
 
 ## Project Structure
 
-- `UI_in_HTML.html` - UI style guide and component library
-- `UI_INTEGRATION_PLAN.md` - Implementation plan for desktop app
-- Additional documentation and source files
+```
+apps/
+  web-client/       # React + Vite front end
+  desktop-studio/   # Tauri wrapper for desktop
+packages/
+  schema/           # Zod data models
+  engine/           # Pure game logic (forge, turn state machine)
+  ui/               # Shared UI components
+```
+
+Additional documentation lives in the `docs/` folder.
+
+### AI Card Suggestion
+On the Forge screen you can click **Suggest Card** to let the engine recommend a
+card from your collection that best matches the edges of the cards you've
+already placed. This feature is optional and doesn't modify your selection until
+you choose to use the suggested card.
 
 ## Contributing
 

--- a/apps/web-client/src/engine.d.ts
+++ b/apps/web-client/src/engine.d.ts
@@ -1,0 +1,9 @@
+declare module '@hexcard/engine' {
+  import type { HexCard } from '@hexcard/schema'
+
+  export type Phase = 'upkeep' | 'hero' | 'action' | 'combat' | 'cleanup'
+  export interface TurnState { turn: number; phase: Phase }
+
+  export function suggestCard(selected: Array<HexCard | null>, deck: HexCard[]): HexCard | null
+  export function nextPhase(state: TurnState): TurnState
+}

--- a/apps/web-client/src/forge/CharacterForge.tsx
+++ b/apps/web-client/src/forge/CharacterForge.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import { useCharacterForgeStore } from './characterForgeStore'
 import type { HexCard } from './forgeSchema'
 import type { Slot } from './forgeLogic'
 import { ForgedHeroSchema } from './forgeSchema'
+import { suggestCard } from '@hexcard/engine'
 
 interface CharacterForgeProps {
   availableCards: HexCard[]
@@ -82,6 +84,7 @@ export default function CharacterForge({ availableCards, onForge }: CharacterFor
   const setCard = useCharacterForgeStore((s) => s.setCard)
   const finalStats = useCharacterForgeStore((s) => s.finalStats)
   const classLabel = useCharacterForgeStore((s) => s.classLabel)
+  const [suggested, setSuggested] = useState<HexCard | null>(null)
 
   const handleForge = () => {
     const hero = {
@@ -98,6 +101,11 @@ export default function CharacterForge({ availableCards, onForge }: CharacterFor
     }
   }
 
+  const handleSuggest = () => {
+    const suggestion = suggestCard(Object.values(equipped), availableCards as any)
+    setSuggested(suggestion)
+  }
+
   return (
     <div className="p-4">
       <input className="border p-1 mb-2" value={name} onChange={(e) => setName(e.target.value)} placeholder="Hero name" />
@@ -108,7 +116,15 @@ export default function CharacterForge({ availableCards, onForge }: CharacterFor
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-20 h-20 rounded-full bg-gray-700" />
       </div>
       <StatPreview />
-      <ForgeButton onForge={handleForge} />
+      <div className="flex gap-2 justify-center">
+        <ForgeButton onForge={handleForge} />
+        <button onClick={handleSuggest} className="mt-4 px-4 py-2 rounded bg-blue-500 text-white">
+          Suggest Card
+        </button>
+      </div>
+      {suggested && (
+        <div className="text-center mt-2 text-sm" data-testid="suggestion">Suggested: {suggested.name}</div>
+      )}
       <div className="flex flex-wrap mt-4">
         {availableCards.map((c) => (
           <CardPreview key={c.id} card={c} />

--- a/packages/engine/src/fuse.ts
+++ b/packages/engine/src/fuse.ts
@@ -1,11 +1,21 @@
 import { randomUUID } from 'crypto'
 import type { HexCard, Character, Ship } from '../../schema/src'
 
-export function fuse(cards: HexCard[], name: string, kind: 'character' | 'ship' = 'character'): Character | Ship {
+/**
+ * Fuse six hex cards into either a character or a ship definition.
+ * Duplicate logic between the two outcomes is avoided by mapping the
+ * resulting card IDs to the appropriate property.
+ */
+export function fuse(
+  cards: HexCard[],
+  name: string,
+  kind: 'character' | 'ship' = 'character'
+): Character | Ship {
   if (cards.length !== 6) throw new Error('exactly six cards required')
+  const ids = cards.map(c => c.id)
   if (kind === 'character') {
     const totalPower = cards.reduce((s, c) => s + (c.power || 0), 0)
-    return { id: randomUUID(), name, totalPower, cardIds: cards.map(c => c.id) }
+    return { id: randomUUID(), name, totalPower, cardIds: ids }
   }
-  return { id: randomUUID(), name, partIds: cards.map(c => c.id) }
+  return { id: randomUUID(), name, partIds: ids }
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -15,7 +15,10 @@ export interface Character {
 
 /**
  * Combine six cards into a new character.
- * Total power is the sum of card power values.
+ *
+ * @param cards - exactly six cards to fuse
+ * @param name  - the resulting character name
+ * @returns the forged character with aggregated power
  */
 export function forgeCharacter(cards: HexCard[], name: string): Character {
   if (cards.length !== 6) {
@@ -32,3 +35,5 @@ export function forgeCharacter(cards: HexCard[], name: string): Character {
 
 export { generateBooster } from './booster'
 export { fuse } from './fuse'
+export { nextPhase, Phase } from './turn'
+export { suggestCard } from './suggest'

--- a/packages/engine/src/suggest.test.ts
+++ b/packages/engine/src/suggest.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { suggestCard } from './suggest'
+import type { HexCard } from '../../schema/src'
+
+const card = (id: string, edge: string[]): HexCard => ({
+  id,
+  name: id,
+  type: 'unit',
+  rarity: 'common',
+  edges: edge as any,
+  tags: []
+})
+
+describe('suggestCard', () => {
+  const deck: HexCard[] = [
+    card('a', ['attack','attack','attack','attack','attack','attack']),
+    card('b', ['defense','defense','defense','defense','defense','defense']),
+    card('c', ['attack','defense','skill','resource','link','element'])
+  ]
+
+  it('suggests card with matching edges', () => {
+    const selected = [deck[0], null, null, null, null, null]
+    const suggestion = suggestCard(selected, deck)
+    expect(suggestion?.id).toBe('c')
+  })
+
+  it('returns null when deck empty', () => {
+    expect(suggestCard([], [])).toBeNull()
+  })
+})

--- a/packages/engine/src/suggest.ts
+++ b/packages/engine/src/suggest.ts
@@ -1,0 +1,36 @@
+import type { HexCard, EdgeIcon } from '../../schema/src'
+
+/**
+ * Recommend a card from `deck` that best matches the edges of
+ * the currently selected cards. Cards already in `selected` are ignored.
+ * Returns `null` if deck is empty or no cards are available.
+ */
+export function suggestCard(selected: Array<HexCard | null>, deck: HexCard[]): HexCard | null {
+  if (deck.length === 0) return null
+
+  // Gather edge frequencies from the selected cards
+  const counts: Partial<Record<EdgeIcon, number>> = {}
+  for (const card of selected) {
+    if (!card) continue
+    card.edges.forEach(edge => {
+      counts[edge] = (counts[edge] ?? 0) + 1
+    })
+  }
+
+  // Filter out cards already selected
+  const usedIds = new Set(selected.filter(Boolean).map(c => (c as HexCard).id))
+  const candidates = deck.filter(c => !usedIds.has(c.id))
+  if (candidates.length === 0) return null
+
+  let best: HexCard | null = null
+  let bestScore = -1
+  for (const card of candidates) {
+    const score = card.edges.reduce((s, e) => s + (counts[e] ?? 0), 0)
+    if (score > bestScore) {
+      bestScore = score
+      best = card
+    }
+  }
+
+  return best
+}

--- a/packages/engine/src/turn.test.ts
+++ b/packages/engine/src/turn.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { nextPhase, TurnState } from './turn'
+
+const start: TurnState = { turn: 1, phase: 'upkeep' }
+
+describe('nextPhase', () => {
+  it('cycles through phases and increments turn', () => {
+    const afterHero = nextPhase(start)
+    expect(afterHero).toEqual({ turn: 1, phase: 'hero' })
+
+    const afterAction = nextPhase(afterHero)
+    expect(afterAction.phase).toBe('action')
+
+    const afterCombat = nextPhase(afterAction)
+    expect(afterCombat.phase).toBe('combat')
+
+    const afterCleanup = nextPhase(afterCombat)
+    expect(afterCleanup.phase).toBe('cleanup')
+
+    const nextTurn = nextPhase(afterCleanup)
+    expect(nextTurn).toEqual({ turn: 2, phase: 'upkeep' })
+  })
+})

--- a/packages/engine/src/turn.ts
+++ b/packages/engine/src/turn.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+
+/**
+ * Available phases of a player's turn. The order
+ * represents the natural progression through a single turn.
+ */
+export const Phase = z.enum(['upkeep', 'hero', 'action', 'combat', 'cleanup'])
+export type Phase = z.infer<typeof Phase>
+
+/**
+ * Turn state tracks the current turn number and phase.
+ */
+export interface TurnState {
+  turn: number
+  phase: Phase
+}
+
+const sequence: Phase[] = ['upkeep', 'hero', 'action', 'combat', 'cleanup']
+
+/**
+ * Advance the turn state to the next phase.
+ * When cleanup is reached, the turn counter is incremented
+ * and the phase cycles back to upkeep.
+ */
+export function nextPhase(state: TurnState): TurnState {
+  const idx = sequence.indexOf(state.phase)
+  const nextIdx = (idx + 1) % sequence.length
+  const nextPhase = sequence[nextIdx]
+  return {
+    turn: nextPhase === 'upkeep' ? state.turn + 1 : state.turn,
+    phase: nextPhase
+  }
+}


### PR DESCRIPTION
## Summary
- simplify fuse logic with clearer comments
- add turn state machine and tests
- implement card suggestion helper with tests
- expose new helpers from engine
- integrate `Suggest Card` button in CharacterForge UI
- document setup instructions and new feature

## Testing
- `npm test` *(fails: vitest not found)*